### PR TITLE
Update coaches section

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,14 +11,16 @@ We'll start at 1:00 pm and go until 5:00 pm. This event is free to attendees bec
 We’re looking for [sponsors](https://docs.google.com/document/d/1l3QvZ0DInVqpiKFsdw4L3ZinT-J4m_wL6JDDRx0uv44/) to cover the costs for this beginner-level coding workshop so that it’s free for community members to attend.
 
 Contact for sponsorship questions and sales, or to request an in-kind or other custom sponsorship package:
+
 ```
-Kimberly Collins 
+Kimberly Collins
 Workshop Facilitator
 kcollins at techlahoma.org
 ```
 
 ### Curriculum
-We'll be using the [Legacy Responsive Web Design](https://www.freecodecamp.org/learn/responsive-web-design/) course on [freeCodeCamp](https://www.freecodecamp.org/)! Brand-new coders will start at the [Basic HTML](https://www.freecodecamp.org/learn/responsive-web-design/#basic-html-and-html5) section. 
+
+We'll be using the [Legacy Responsive Web Design](https://www.freecodecamp.org/learn/responsive-web-design/) course on [freeCodeCamp](https://www.freecodecamp.org/)! Brand-new coders will start at the [Basic HTML](https://www.freecodecamp.org/learn/responsive-web-design/#basic-html-and-html5) section.
 
 If you've worked on this course before, you can start where you left off. Be sure to log in to save your progress! The goal for this workshop is to get as far in this course as possible. If you've already finished this certification, consider coaching or volunteering instead!
 
@@ -27,35 +29,41 @@ If you've worked on this course before, you can start where you left off. Be sur
 Our audience for this workshop is adults learning about coding with HTML and CSS. We expect to have 20-30 attendees, 10-12 volunteers (including coaches), and a facilitator. Coaches will be experienced developers. Members of underrepresented groups are highly encouraged to attend!
 
 #### Attendees
-* We'll let you know whether your [application to attend](https://forms.gle/zwhcyCNG3WXxtbYo6) is accepted as soon as we can.
-* You'll need to bring a laptop to this workshop. If you don't have access to one, you can [borrow a Chromebook](https://www.metrolibrary.org/discover/technology#computers) from the Metropolitan Library System.
-* We'll be communicating with participants through [Techlahoma's Slack](https://fccokc.com/slack), so joining it is a requirement for this workshop!
+
+- We'll let you know whether your [application to attend](https://forms.gle/zwhcyCNG3WXxtbYo6) is accepted as soon as we can.
+- You'll need to bring a laptop to this workshop. If you don't have access to one, you can [borrow a Chromebook](https://www.metrolibrary.org/discover/technology#computers) from the Metropolitan Library System.
+- We'll be communicating with participants through [Techlahoma's Slack](https://fccokc.com/slack), so joining it is a requirement for this workshop!
 
 #### Coaches and Volunteers
-* We'll need some [coaches](https://forms.gle/PPyB5aY3EwwHvdkm6) for this workshop! Coaching is pretty low-key and low-stress.
-* If we have enough coaches, we may still need your help as a general volunteer!
+
+- ~~We'll need some coaches for this workshop! Coaching is pretty low-key and low-stress.~~
+- We have enough coaches, but contact us about volunteering in other ways!
 
 #### Facilitator
-* Please contact facilitator Kimberly Collins (kcollins at techlahoma.org) if you have any questions about the workshop or are interested in sponsorship or volunteering!
-* [Kimberly](https://www.linkedin.com/in/collins-kimberly/) is a professional software development consultant with 16 years of experience and strong ties to the local technology community. She has organized numerous user group meetups and networking events, been involved in coding bootcamps, given talks, and mentored junior developers. She has facilitated workshops on Django, Ruby on Rails, and HTML/CSS and is excited about this one!
+
+- Please contact facilitator Kimberly Collins (kcollins at techlahoma.org) if you have any questions about the workshop or are interested in sponsorship or volunteering!
+- [Kimberly](https://www.linkedin.com/in/collins-kimberly/) is a professional software development consultant with 16 years of experience and strong ties to the local technology community. She has organized numerous user group meetups and networking events, been involved in coding bootcamps, given talks, and mentored junior developers. She has facilitated workshops on Django, Ruby on Rails, and HTML/CSS and is excited about this one!
 
 ## HTML and CSS
 
 What are HTML and CSS? Read about them in The Odin Project's [foundations course](https://www.theodinproject.com/lessons/foundations-introduction-to-html-and-css)!
 
 ### HTML Resources
-* [Codecademy Cheatsheets](https://www.codecademy.com/learn/learn-html/modules/learn-html-elements/cheatsheet)
-* [MDN Web Docs](https://developer.mozilla.org/en-US/docs/Web/HTML)
-* [W3Schools](https://www.w3schools.com/html/)
+
+- [Codecademy Cheatsheets](https://www.codecademy.com/learn/learn-html/modules/learn-html-elements/cheatsheet)
+- [MDN Web Docs](https://developer.mozilla.org/en-US/docs/Web/HTML)
+- [W3Schools](https://www.w3schools.com/html/)
 
 ### CSS Resources
-* [Codecademy Cheatsheets](https://www.codecademy.com/learn/learn-css/modules/syntax-and-selectors/cheatsheet)
-* [CSS Tricks](https://css-tricks.com/)
-* [MDN Web Docs](https://developer.mozilla.org/en-US/docs/Web/CSS)
-* [W3Schools](https://www.w3schools.com/css/)
+
+- [Codecademy Cheatsheets](https://www.codecademy.com/learn/learn-css/modules/syntax-and-selectors/cheatsheet)
+- [CSS Tricks](https://css-tricks.com/)
+- [MDN Web Docs](https://developer.mozilla.org/en-US/docs/Web/CSS)
+- [W3Schools](https://www.w3schools.com/css/)
 
 ## Techlahoma
-This workshop is hosted by the [Techlahoma Foundation](https://www.techlahoma.org/), a professional network of more than 5,000 information technology workers, hobbyists, students, teachers, and future technologists. 
+
+This workshop is hosted by the [Techlahoma Foundation](https://www.techlahoma.org/), a professional network of more than 5,000 information technology workers, hobbyists, students, teachers, and future technologists.
 
 Techlahoma hosts monthly user group meetups and 3 annual conferences (200 OK, UXOK, and ThunderPlains) that train on the latest skills needed to obtain employment and succeed in today's increasingly tech-focused workforce. We teach and discuss topics ranging from design, coding, data science, hardware, mobile apps, and much more.
 


### PR DESCRIPTION
Addresses issue #6. I decided to strikethrough a previous line item to show we did ask for coaches but now have enough. I also removed the link to the coaches sign-up form. 

**Note**: I use Prettier in my editor and it did format the code. Let me know if you want me to undo those changes.

<img width="781" alt="Screen Shot 2022-10-03 at 9 50 31 PM" src="https://user-images.githubusercontent.com/100741044/193724094-5e55e3af-4269-4876-a7ee-1cb92c7f6acb.png">
